### PR TITLE
[be] fix: 카테고리별 피드백 목록 검색기능 및 기타 수정

### DIFF
--- a/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/controller/FeedbackBoardController.java
+++ b/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/controller/FeedbackBoardController.java
@@ -5,7 +5,6 @@ import com.CreatorConnect.server.board.feedbackboard.service.FeedbackBoardServic
 import com.CreatorConnect.server.board.feedbackboard.dto.FeedbackBoardDto;
 import com.CreatorConnect.server.board.feedbackboard.dto.FeedbackBoardResponseDto;
 import com.CreatorConnect.server.board.feedbackboard.entity.FeedbackBoard;
-import com.CreatorConnect.server.board.feedbackboard.mapper.FeedbackBoardMapper;
 import com.CreatorConnect.server.board.tag.entity.Tag;
 import com.CreatorConnect.server.board.tag.mapper.TagMapper;
 import com.CreatorConnect.server.member.bookmark.entity.Bookmark;
@@ -34,7 +33,6 @@ import java.util.stream.Collectors;
 public class FeedbackBoardController {
     private final FeedbackBoardService feedbackBoardService;
     private final FeedbackBoardRepository feedbackBoardRepository;
-    private final FeedbackBoardMapper mapper;
     private final TagMapper tagMapper;
     private final MemberService memberService;
     private final MemberRepository memberRepository;

--- a/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/controller/FeedbackBoardController.java
+++ b/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/controller/FeedbackBoardController.java
@@ -71,12 +71,24 @@ public class FeedbackBoardController {
         FeedbackBoardResponseDto.Multi response = feedbackBoardService.responseFeedbacks(sort, page, size);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
+    //목록조회 -> 피드백 카테고리(선택) - 카테고리(전체)
     @GetMapping("/feedbackboards/feedbackcategories/{feedbackCategoryId}")
     public ResponseEntity getFeedbacksByFeedbackCategory(@PathVariable("feedbackCategoryId") @Positive Long feedbackCategoryId,
                                                          @RequestParam("sort") String sort,
                                                          @RequestParam("page") @Positive int page,
                                                          @RequestParam("size") @Positive int size) {
         FeedbackBoardResponseDto.Multi response = feedbackBoardService.responseFeedbacksByCategory(feedbackCategoryId, sort, page, size);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    //목록조회 -> 피드백 카테고리(선택) - 카테고리(선택)
+    @GetMapping("/feedbackboards/feedbackcategories/{feedbackCategoryId}/categories/{categoryId}")
+    public ResponseEntity getFeedbacksByFeedbackCategoryAndCategory(@PathVariable("feedbackCategoryId") @Positive Long feedbackCategoryId,
+                                                         @PathVariable("categoryId") @Positive Long categoryId,
+                                                         @RequestParam("sort") String sort,
+                                                         @RequestParam("page") @Positive int page,
+                                                         @RequestParam("size") @Positive int size) {
+        FeedbackBoardResponseDto.Multi response = feedbackBoardService.responseFeedbacksByCategory(feedbackCategoryId, categoryId, sort, page, size);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
     @DeleteMapping("/feedbackboard/{feedbackBoardId}")

--- a/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/dto/FeedbackBoardDto.java
+++ b/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/dto/FeedbackBoardDto.java
@@ -19,7 +19,6 @@ public class FeedbackBoardDto {
         private String title;
         private String link;
         private String content;
-//        private String tag;
         private String categoryName;
         private String feedbackCategoryName;
         private List<TagDto.TagInfo> tags; // 태그
@@ -39,7 +38,6 @@ public class FeedbackBoardDto {
         private String title;
         private String link;
         private String content;
-//        private String tag;
         private String categoryName;
         private String feedbackCategoryName;
         private List<TagDto.TagInfo> tags; // 태그

--- a/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/dto/FeedbackBoardResponseDto.java
+++ b/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/dto/FeedbackBoardResponseDto.java
@@ -26,7 +26,6 @@ public class FeedbackBoardResponseDto {
         private long feedbackBoardId;
         private String title;
         private String content;
-//        private String tag;
         private String categoryName;
         private String feedbackCategoryName;
         private List<TagDto.TagInfo> tags; // 태그

--- a/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/mapper/FeedbackBoardMapper.java
+++ b/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/mapper/FeedbackBoardMapper.java
@@ -15,8 +15,6 @@ public interface FeedbackBoardMapper {
     FeedbackBoard feedbackBoardPatchDtoToFeedbackBoard(FeedbackBoardDto.Patch feedbackBoardPatchDto);
     FeedbackBoardResponseDto.Patch feedbackBoardToFeedbackBoardPatchResponse(FeedbackBoard feedbackBoard);
     FeedbackBoardResponseDto.Details feedbackBoardToFeedbackBoardDetailsResponse(FeedbackBoard feedbackBoard);
-    List<FeedbackBoardResponseDto.Details>  feedbackBoardsToFeedbackBoardDetailsResponses (List<FeedbackBoard> feedbackBoards);
-
     // 게시글 목록 조회 시 Response를 위한 매핑
     FeedbackBoardResponseDto.Details feedbackBoardToResponse(FeedbackBoard feedbackBoard, List<TagDto.TagInfo> tags);
 

--- a/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/repository/FeedbackBoardRepository.java
+++ b/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/repository/FeedbackBoardRepository.java
@@ -16,4 +16,7 @@ public interface FeedbackBoardRepository extends JpaRepository<FeedbackBoard, Lo
     @Query("select f from FeedbackBoard f where f.feedbackCategory.feedbackCategoryId = :feedbackCategoryId")
     Page<FeedbackBoard> findFeedbackBoardsByFeedbackCategoryId(@Param("feedbackCategoryId") long feedbackCategoryId, Pageable pageable);
 
+    @Query("select f from FeedbackBoard f where f.feedbackCategory.feedbackCategoryId = :feedbackCategoryId And f.category.categoryId = :categoryId")
+    Page<FeedbackBoard> findFeedbackBoardsByFeedbackCategoryIdAndCategoryId(@Param("feedbackCategoryId") long feedbackCategoryId, @Param("categoryId") long categoryId, Pageable pageable);
+
 }

--- a/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/service/FeedbackBoardService.java
+++ b/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/service/FeedbackBoardService.java
@@ -101,17 +101,12 @@ public class FeedbackBoardService {
             foundFeedbackBoard.setCategory(category.orElseThrow(() ->
                     new BusinessLogicException(ExceptionCode.CATEGORY_NOT_FOUND)));
         }
-//        Optional<Category> category = categoryRepository.findByCategoryName(patchDto.getCategoryName());
-//        foundFeedbackBoard.setCategory(category.orElseThrow(() -> new BusinessLogicException(ExceptionCode.CATEGORY_NOT_FOUND)));
 
         // 피드백 카테고리를 수정할 경우 카테고리 유효성 검증
         if (patchDto.getFeedbackCategoryName() != null) { // 피드백 카테고리가 변경이 된경우
             Optional<FeedbackCategory> feedbackCategory = feedbackCategoryRepository.findByFeedbackCategoryName(patchDto.getFeedbackCategoryName());
             foundFeedbackBoard.setFeedbackCategory(feedbackCategory.orElseThrow(() -> new BusinessLogicException(ExceptionCode.FEEDBACK_CATEGORY_NOT_FOUND)));
         }
-
-//        Optional.ofNullable(feedbackBoard.getTag())
-//                .ifPresent(foundFeedbackBoard::setTag);
 
         // 저장
         FeedbackBoard updatedFeedbackBoard = feedbackBoardRepository.save(foundFeedbackBoard);

--- a/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/service/FeedbackBoardService.java
+++ b/server/src/main/java/com/CreatorConnect/server/board/feedbackboard/service/FeedbackBoardService.java
@@ -190,8 +190,20 @@ public class FeedbackBoardService {
         // page생성 - 피드백 카테고리 ID로 검색 후 정렬 적용
         Page<FeedbackBoard> feedbackBoardsPage = feedbackBoardRepository.findFeedbackBoardsByFeedbackCategoryId(feedbackCategoryId, sortedPageRequest(sort, page, size));
 
-        // 피드백 리스트 가져오기
-//        List<FeedbackBoardResponseDto.Details> responses = mapper.feedbackBoardsToFeedbackBoardDetailsResponses(feedbackBoardsPage.getContent());
+        // pageInfo 가져오기
+        FeedbackBoardResponseDto.PageInfo pageInfo = new FeedbackBoardResponseDto.PageInfo(feedbackBoardsPage.getNumber() + 1, feedbackBoardsPage.getSize(), feedbackBoardsPage.getTotalElements(), feedbackBoardsPage.getTotalPages());
+
+        // 태그 정보 적용
+        List<FeedbackBoardResponseDto.Details> responses = getResponseList(feedbackBoardsPage);
+
+        //리턴
+        return new FeedbackBoardResponseDto.Multi<>(responses, pageInfo);
+    }
+
+    //피드백 카테고리 - 카테고리별 목록 조회
+    public FeedbackBoardResponseDto.Multi<FeedbackBoardResponseDto.Details> responseFeedbacksByCategory(Long feedbackCategoryId, Long categoryId, String sort, int page, int size){
+        // page생성 - 피드백 카테고리 ID 와 카테고리 ID로 검색 후 정렬 적용
+        Page<FeedbackBoard> feedbackBoardsPage = feedbackBoardRepository.findFeedbackBoardsByFeedbackCategoryIdAndCategoryId(feedbackCategoryId, categoryId, sortedPageRequest(sort, page, size));
 
         // pageInfo 가져오기
         FeedbackBoardResponseDto.PageInfo pageInfo = new FeedbackBoardResponseDto.PageInfo(feedbackBoardsPage.getNumber() + 1, feedbackBoardsPage.getSize(), feedbackBoardsPage.getTotalElements(), feedbackBoardsPage.getTotalPages());

--- a/server/src/main/java/com/CreatorConnect/server/board/freeboard/controller/FreeBoardController.java
+++ b/server/src/main/java/com/CreatorConnect/server/board/freeboard/controller/FreeBoardController.java
@@ -1,4 +1,4 @@
-package com.CreatorConnect.server.board.freeboard.conroller;
+package com.CreatorConnect.server.board.freeboard.controller;
 
 import com.CreatorConnect.server.board.categories.category.service.CategoryService;
 import com.CreatorConnect.server.board.freeboard.dto.FreeBoardDto;
@@ -91,7 +91,7 @@ public class FreeBoardController {
     }
 
     // 자유 게시판 카테고리 별 목록 조회
-    @GetMapping("/freboards/category/{categoryId}")
+    @GetMapping("/freeboards/categories/{categoryId}")
     public ResponseEntity getFreeBoardsByCategory(@PathVariable("categoryId") long categoryId,
                                                   @RequestParam String sort,
                                                   @Positive @RequestParam int page,

--- a/server/src/main/java/com/CreatorConnect/server/board/tag/entity/TagToFeedbackBoard.java
+++ b/server/src/main/java/com/CreatorConnect/server/board/tag/entity/TagToFeedbackBoard.java
@@ -13,7 +13,7 @@ import javax.persistence.*;
 public class TagToFeedbackBoard { // 피드백 게시판 - 태그 매핑 테이블
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long feedbackBoardId;
+    private Long tagToFeedbackBoardId;
 
     @ManyToOne
     @JoinColumn(name = "FEEDBACKBOARD_ID")


### PR DESCRIPTION
1.  카테고리별 피드백 목록 조회기능 두개로 분할
 피드백 카테고리(선택) - 카테고리 (전체) 조회 기능
 피드백 카테고리(선택) - 카테고리(선택) 기능

2. 피드백보드 안쓰는 import, 주석 코드 삭제
3. TagToFeedbackBoard ID 컬럼네임 수정 FeedbackBoardId -> tagToFeedbackBoardId
4. freeboard  컨트롤러 폴더 이름 및 카테고리별 목록조회 URL /freeboards/categories/{categoryId}로 수정